### PR TITLE
fix: profile_edit 후 재로그인시 변경사항 반영안되는 문제 해결

### DIFF
--- a/backend/login/views.py
+++ b/backend/login/views.py
@@ -34,7 +34,7 @@ def callback(request):
     if not user_data:
         return Response(status=401)
 
-    user, created = save_or_update_user(user_data)
+    user, created = get_or_save_user(user_data)
     # Test 위해서 True로 설정
     # user.is_2FA = True
     if created:
@@ -78,14 +78,14 @@ def get_user_info(access_token):
     return None
 
 
-def save_or_update_user(user_data):
+def get_or_save_user(user_data):
 
     user_uid = user_data.get("id")
     nickname = user_data.get("login")
     email = user_data.get("email")
     img_url = user_data.get("image", {}).get("link")
 
-    user, created = User.objects.update_or_create(
+    user, created = User.objects.get_or_create(
         user_id=user_uid,
         defaults={
             "user_id": user_uid,


### PR DESCRIPTION
## 주요 구현 사항

- django ORM에서 제공하는 update_or_create() 메소드를 get_or_create() 메소드로 변경해서 db에 이미 있는 유저면 업데이트 하지 않게 바꿈!


## 리뷰어 참고 사항

- 이제 profile edit 하고 logout -> login 다시 하면 변경사항 잘 적용되어 있습니다!
